### PR TITLE
Update number.ts

### DIFF
--- a/src/parsers/number.ts
+++ b/src/parsers/number.ts
@@ -9,6 +9,7 @@ import {
 
 interface NumberOptions extends StandardOptions {
   readonly allowNumeric?: boolean;
+  readonly fullNumberOnly?: boolean;
 }
 
 export const NumberParser = <TOptions extends NumberOptions>(
@@ -66,8 +67,9 @@ const handleNonNumber = (
     }
 
     const parsed = parseFloat(inp.value);
+    const isFull = (parsed + '') === inp.value
 
-    if (!isNaN(parsed)) {
+    if (!isNaN(parsed) && (!options.fullNumberOnly || isFull)) {
       return {
         value: parsed,
         errors: []


### PR DESCRIPTION
The allowNumeric option allows numerical strings to be parsed, but there is no case to handle strings with mixed content. 

Consider how these strings are currently parsed:
'123' -> 123
'abc123' -> Error
'123abc' -> 123

In the third example the string is parsed as a number. This behaviour is okay but it would be good to also have the option to be strict about the full numeracy of the string.

Enabling the fullNumberOnlyOption in conjunction with allowNumeric changes the mapping to this
'19' -> 19
'a19' -> Error
'19a' -> Error

Code untested.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
