### PR TITLE
Implement allowNumeric for StringParser, add expect-type library

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "@types/node": "^12.6.2",
     "codecov": "^3.5.0",
     "cz-conventional-changelog": "^2.1.0",
+    "expect-type": "^0.14.2",
     "gh-pages": "^2.0.1",
     "mocha": "^6.1.4",
     "npm-run-all": "^4.1.5",

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import { expectTypeOf } from 'expect-type';
 import {
   getValid,
   NumberParser,
@@ -40,9 +41,9 @@ describe('index', () => {
       }
 
       // Check schema conformance
-      const answer: Schema = result;
+      expectTypeOf(result).toMatchTypeOf<Schema>();
 
-      deepEqual(answer, { a: 1, b: null, c: 'foo' });
+      deepEqual(result, { a: 1, b: null, c: 'foo' });
       deepEqual(errors, []);
     });
 
@@ -125,9 +126,22 @@ describe('index', () => {
       }
 
       // Check schema conformance
-      const answer: Schema = result;
+      expectTypeOf(result).toMatchTypeOf<Schema>();
+      expectTypeOf(result).not.toMatchTypeOf<
+        Schema & {
+          readonly tuple: readonly [unknown, unknown];
+        }
+      >();
+      expectTypeOf(result).not.toMatchTypeOf<
+        Schema & {
+          readonly objectArray: readonly {
+            readonly a: number;
+            readonly b: boolean;
+          }[];
+        }
+      >();
 
-      deepEqual(answer, {
+      deepEqual(result, {
         num: 1,
         tuple: [1, 'thing', undefined],
         object: { a: 1, b: 'foo' },

--- a/src/parsers/number.ts
+++ b/src/parsers/number.ts
@@ -9,13 +9,20 @@ import {
 
 interface NumberOptions extends StandardOptions {
   readonly allowNumeric?: boolean;
+  readonly allowTypeCoercion?: boolean;
 }
 
 export const NumberParser = <TOptions extends NumberOptions>(
-  options?: TOptions
+  optionsParameter?: TOptions
 ) => (
   inp: ParserInput
 ): ParserResult<number | StandardOptionsReturn<TOptions>> => {
+  const options = {
+    allowTypeCoercion: true,
+    ...optionsParameter
+    // tslint:disable-next-line: no-object-literal-type-assertion
+  } as TOptions;
+
   const emptyResult = checkEmpty(inp, options);
 
   if (emptyResult) {
@@ -51,14 +58,14 @@ const handleNonNumber = (
   options?: NumberOptions
 ): ParserResult<any> | null => {
   if (typeof inp.value === 'string' && options && options.allowNumeric) {
-    if (inp.value === '' && options.optional) {
+    if (inp.value === '' && options.optional && options.allowTypeCoercion) {
       return {
         value: undefined,
         errors: []
       };
     }
 
-    if (inp.value === 'null' && options.nullable) {
+    if (inp.value === 'null' && options.nullable && options.allowTypeCoercion) {
       return {
         value: null,
         errors: []

--- a/src/parsers/string.ts
+++ b/src/parsers/string.ts
@@ -27,15 +27,20 @@ export const StringParser = <TOptions extends StringOptions>(
   }
 
   if (typeof inp.value !== 'string') {
-    return {
-      value: ValidationFail,
-      errors: [
-        {
-          path: inp.path,
-          message: `Value "${inp.value}" is not a string`
-        }
-      ]
-    };
+    if (typeof inp.value === 'number' && options && options.allowNumeric) {
+      // tslint:disable-next-line: no-parameter-reassignment
+      inp = { value: inp.value.toString(), path: inp.path };
+    } else {
+      return {
+        value: ValidationFail,
+        errors: [
+          {
+            path: inp.path,
+            message: `Value "${inp.value}" is not a string`
+          }
+        ]
+      };
+    }
   }
 
   const errors: ValidationError[] = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -957,6 +957,11 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+expect-type@^0.14.2:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-0.14.2.tgz#3924d0e596455a9b27af48e8a99c582cdd4506eb"
+  integrity sha512-ed3+tr5ujbIYXZ8Pl/VgIphwJQ0q5tBLGGdn7Zvwt1WyPBRX83xjT5pT77P/GkuQbctx0K2ZNSSan7eruJqTCQ==
+
 figures@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.0.0.tgz#756275c964646163cc6f9197c7a0295dbfd04de9"


### PR DESCRIPTION
Hello, @cjdell! Phenomenal work, mate, 10/10. I was wondering if you were aware of this handy library called `expect-type`, it can be pretty useful in a type-heavy project like this one. I don't know if you'll find it useful, but I added a couple of lines of tests just as an example.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
A bug fix, a feature and a type testing library